### PR TITLE
Add database scripts; make first migration

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,4 +10,5 @@ dependencies = [
     "numpy>=2.2.0",
     "requests>=2.32.3",
     "pillow>=11.0.0",
+    "python-dotenv>=1.0.1",
 ]

--- a/backend/server/db/base.py
+++ b/backend/server/db/base.py
@@ -3,18 +3,14 @@ import sqlite3
 from flask import g
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
+SCHEMA_DIR = os.path.join(base_dir, 'sql')
 
+DEFAULT_DATABASE = os.path.join(base_dir, '../main.db')
+DATABASE = os.getenv('DATABASE', DEFAULT_DATABASE)
 
-DATABASE = os.path.join(base_dir, 'main.db')
-SCHEMA = os.path.join(base_dir, 'schema.sql')
-
-def init_db():
-    conn = sqlite3.connect(DATABASE)
-    fp = open(SCHEMA, 'r')
-    conn.executescript(fp.read())
-    conn.close()
-
-def connect():
+def connect(path=None):
+    if path is None:
+        path = DATABASE
     conn = sqlite3.connect(DATABASE)
     conn.row_factory = sqlite3.Row
     return conn

--- a/backend/server/db/manage.py
+++ b/backend/server/db/manage.py
@@ -1,0 +1,94 @@
+import argparse
+import os
+import os.path
+import sqlite3
+
+import sys
+base_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, base_dir)        # hack!
+from base import DATABASE, SCHEMA_DIR
+
+SCHEMA = os.path.join(SCHEMA_DIR, 'schema.sql')
+
+def list_migrations():
+    migrations = []
+    for f in os.listdir(SCHEMA_DIR):
+        if f.lower().endswith('.sql') and '_' in f:
+            try:
+                id = int(f.split('_')[0])  # Ensure ID is an integer
+                migrations.append((id, os.path.join(SCHEMA_DIR, f)))
+            except ValueError:
+                print(f'Skipping invalid migration file: {f}')
+    return sorted(migrations, key=lambda pair: pair[0])  # Sort by ID                   # sort by the id
+
+def execute_script(conn, path):
+    _, name = os.path.split(path)
+    print(f'Executing {name}...')
+    with open(path) as fp:
+        conn.executescript(fp.read())
+        
+def init_db(conn):
+    execute_script(conn, SCHEMA)
+    conn.commit()
+    
+def latest_migration(conn, show=False):
+    row = conn.execute('SELECT id, description FROM migrations ORDER BY id DESC LIMIT 1;').fetchone()
+    last_id, description = row if row else (0, 'Initial version.')
+    
+    if show:
+        print(f'Latest applied: #{last_id}\n{description}')
+
+    return last_id, description
+
+def migrate_db(conn):
+    last_id, description = latest_migration(conn, show=True)
+    
+    migrations = list_migrations()
+    print(f'Found {len(migrations)} migrations. Now applying the latest {len(migrations)-last_id}.')
+    
+    for id, path in migrations:
+        if id <= last_id:
+            print(f'Skipping #{id}.')
+            continue
+        execute_script(conn, path)
+
+        desc = os.path.splitext(os.path.split(path)[1]).replace('_', ' '))[0].capitalize()
+        conn.execute('INSERT INTO migrations (id, description) VALUES (?, ?)', (id, desc))
+
+    print('Done.')
+    conn.commit()
+
+def main():
+    parser = argparse.ArgumentParser(description='Database management.')
+    parser.add_argument('action', choices=['init', 'migrate', 'status', 'list'],
+                        help='Action to perform.')
+    parser.add_argument('-d', '--database', type=str, 
+        default='<default>', help='Path to the SQLite database file.')
+    
+    args = parser.parse_args()
+    args.database = args.database if args.database != '<default>' else DATABASE
+
+    print(f'[CURRENT DATABASE: {DATABASE}]\n')
+
+    with sqlite3.connect(args.database) as conn:
+        if args.action == 'init':
+            if os.path.exists(args.database):
+                out = input('WARNING: Database {args.database} already exists. Overwrite it (y/N)? ').lower()
+                if out[:1] != 'y':
+                    print('Aborting.')
+                    return
+            init_db(conn)
+            
+        elif args.action == 'migrate':
+            migrate_db(conn)
+            
+        elif args.action == 'status':
+            last_id, description = latest_migration(conn, show=True)
+            migrations = list_migrations()
+            print(f'Found {len(migrations)} migrations in total.\n{len(migrations)-last_id} unapplied.')
+            
+        elif args.action == 'list':
+            print('\n'.join(f'{os.path.split(p[1])[-1]}' for p in list_migrations()))
+
+if __name__ == '__main__':
+    main()

--- a/backend/server/db/sql/1_add_entry_date.sql
+++ b/backend/server/db/sql/1_add_entry_date.sql
@@ -1,0 +1,32 @@
+-- Check if the 'created_at' column already exists in the 'users' table.
+PRAGMA foreign_keys=off;
+
+CREATE TABLE Entries_new (
+    user_id VARCHAR(255),
+    entry_id INT NOT NULL,
+    date_created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    content TEXT NOT NULL,       -- text, either just a text or a description of the image
+
+    is_image BOOLEAN DEFAULT false,
+    width INT,
+    height INT,
+    image_mini_base64 TEXT,
+    embedding TEXT,
+    pca TEXT,
+
+    PRIMARY KEY (user_id, entry_id),
+    FOREIGN KEY (user_id) REFERENCES Users(user_id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+INSERT INTO Entries_new(
+user_id, entry_id, content, is_image,
+width, height, image_mini_base64, embedding, pca)
+SELECT * FROM Entries;
+
+-- Step 3: Drop the old table
+DROP TABLE Entries;
+
+-- Step 4: Rename the new table to the original table name
+ALTER TABLE Entries_new RENAME TO Entries;
+
+PRAGMA foreign_keys=on;

--- a/backend/server/db/sql/2_add_ip_addr.sql
+++ b/backend/server/db/sql/2_add_ip_addr.sql
@@ -1,0 +1,1 @@
+ALTER TABLE Users ADD COLUMN ip_addr VARCHAR(50);

--- a/backend/server/db/sql/schema.sql
+++ b/backend/server/db/sql/schema.sql
@@ -1,6 +1,6 @@
 DROP TABLE IF EXISTS Users;
 DROP TABLE IF EXISTS Entries;
-
+DROP TABLE IF EXISTS migrations;
 CREATE TABLE Users (
     user_id VARCHAR(255) PRIMARY KEY,
     total_entries INT DEFAULT 0,
@@ -21,4 +21,10 @@ CREATE TABLE Entries (
 
     PRIMARY KEY (user_id, entry_id),
     FOREIGN KEY (user_id) REFERENCES Users(user_id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS migrations (
+    id INTEGER PRIMARY KEY,
+    description TEXT NOT NULL,
+    applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -355,6 +355,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.3"
 source = { registry = "https://pypi.org/simple" }
@@ -378,6 +387,7 @@ dependencies = [
     { name = "flask-cors" },
     { name = "numpy" },
     { name = "pillow" },
+    { name = "python-dotenv" },
     { name = "requests" },
 ]
 
@@ -387,6 +397,7 @@ requires-dist = [
     { name = "flask-cors", specifier = ">=5.0.0" },
     { name = "numpy", specifier = ">=2.2.0" },
     { name = "pillow", specifier = ">=11.0.0" },
+    { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "requests", specifier = ">=2.32.3" },
 ]
 


### PR DESCRIPTION
1. Added a script for managing the database (listing available migrations, etc.).
2. Migrations are kept track of in the database, using `migrations` table.
3. Made things more flexible by relying on the `DATABASE` environment variable.
4. Added `dotenv`.